### PR TITLE
Fix http status of the response

### DIFF
--- a/news/8.feature
+++ b/news/8.feature
@@ -1,0 +1,1 @@
+The http status of the response is changed from 301 (Moved Permanently) to 302 (Found) for GET requests and to 307 (Temporary Redirect) for other request methods because nothing prevents the URL to be reused in the future. [ale-rt]

--- a/plone/app/redirector/browser.py
+++ b/plone/app/redirector/browser.py
@@ -84,7 +84,17 @@ class FourOhFourView(BrowserView):
         # some analytics programs might use this info to track
         if query_string:
             url += "?" + query_string
-        self.request.response.redirect(url, status=301, lock=1)
+
+        # Answer GET requests with 302 (Found). Every other method will be answered
+        # with 307 (Temporary Redirect), which instructs the client to NOT
+        # switch the method (if the original request was a POST, it should
+        # re-POST to the new URL from the Location header).
+        if self.request.method.upper() == "GET":
+            status = 302
+        else:
+            status = 307
+
+        self.request.response.redirect(url, status=status, lock=1)
         return True
 
     def find_redirect_if_view(self, old_path_elements, storage):

--- a/plone/app/redirector/tests/test_view.py
+++ b/plone/app/redirector/tests/test_view.py
@@ -38,7 +38,7 @@ class TestRedirectorView(unittest.TestCase):
         self.storage.add(fp + '/foo', fp + '/bar')
         view = self.view(self.portal, fu + '/foo')
         self.assertEqual(True, view.attempt_redirect())
-        self.assertEqual(301, self.request.response.getStatus())
+        self.assertEqual(302, self.request.response.getStatus())
         self.assertEqual(fu + '/bar',
             self.request.response.getHeader('location'))
 
@@ -48,7 +48,7 @@ class TestRedirectorView(unittest.TestCase):
         self.storage.add(fp + '/foo', fp + '/bar')
         view = self.view(self.portal, fu + '/foo/view')
         self.assertEqual(True, view.attempt_redirect())
-        self.assertEqual(301, self.request.response.getStatus())
+        self.assertEqual(302, self.request.response.getStatus())
         self.assertEqual(fu + '/bar/view',
             self.request.response.getHeader('location'))
 
@@ -58,7 +58,7 @@ class TestRedirectorView(unittest.TestCase):
         self.storage.add(fp + '/foo', fp + '/bar')
         view = self.view(self.portal, fu + '/foo/@@view/part')
         self.assertEqual(True, view.attempt_redirect())
-        self.assertEqual(301, self.request.response.getStatus())
+        self.assertEqual(302, self.request.response.getStatus())
         self.assertEqual(fu + '/bar/@@view/part',
             self.request.response.getHeader('location'))
 
@@ -66,13 +66,13 @@ class TestRedirectorView(unittest.TestCase):
         fu = self.folder.absolute_url()
         view = self.view(self.portal, fu + '/foo')
         self.assertEqual(False, view.attempt_redirect())
-        self.assertNotEqual(301, self.request.response.getStatus())
+        self.assertNotEqual(302, self.request.response.getStatus())
 
     def test_attempt_redirect_with_unknown_url_with_illegal_characters(self):
         fu = self.folder.absolute_url()
         view = self.view(self.portal, fu + '+LÃ¤nder')
         self.assertEqual(False, view.attempt_redirect())
-        self.assertNotEqual(301, self.request.response.getStatus())
+        self.assertNotEqual(302, self.request.response.getStatus())
 
     def test_attempt_redirect_with_quoted_url(self):
         fp = '/'.join(self.folder.getPhysicalPath())
@@ -80,7 +80,7 @@ class TestRedirectorView(unittest.TestCase):
         self.storage.add(fp + '/foo', fp + '/bar')
         view = self.view(self.portal, fu + '/foo/baz%20quux')
         self.assertEqual(True, view.attempt_redirect())
-        self.assertEqual(301, self.request.response.getStatus())
+        self.assertEqual(302, self.request.response.getStatus())
         self.assertEqual(fu + '/bar/baz%20quux',
             self.request.response.getHeader('location'))
 
@@ -90,7 +90,7 @@ class TestRedirectorView(unittest.TestCase):
         self.storage.add(fp + '/foo?blah=blah', fp + '/bar')
         view = self.view(self.portal, fu + '/foo', 'blah=blah')
         self.assertEqual(True, view.attempt_redirect())
-        self.assertEqual(301, self.request.response.getStatus())
+        self.assertEqual(302, self.request.response.getStatus())
         self.assertEqual(fu + '/bar',
             self.request.response.getHeader('location'))
 
@@ -100,7 +100,7 @@ class TestRedirectorView(unittest.TestCase):
         self.storage.add(fp + '/foo', fp + '/bar')
         view = self.view(self.portal, fu + '/foo', 'blah=blah')
         self.assertEqual(True, view.attempt_redirect())
-        self.assertEqual(301, self.request.response.getStatus())
+        self.assertEqual(302, self.request.response.getStatus())
         self.assertEqual(fu + '/bar?blah=blah',
             self.request.response.getHeader('location'))
 
@@ -111,7 +111,7 @@ class TestRedirectorView(unittest.TestCase):
                          'http://otherhost' + fp + '/bar%20qux corge')
         view = self.view(self.portal, fu + '/foo')
         self.assertEqual(True, view.attempt_redirect())
-        self.assertEqual(301, self.request.response.getStatus())
+        self.assertEqual(302, self.request.response.getStatus())
         self.assertEqual('http://otherhost' + fp + '/bar%20qux%20corge',
             self.request.response.getHeader('location'))
 


### PR DESCRIPTION
The http status of the response is changed from 301 (Moved Permanently)
to 302 (Found) for GET requests and to 307 (Temporary Redirect) for
other request methods because nothing prevents the URL to be reused in
the future.

This was inspired by https://github.com/plone/plone.rest/pull/76